### PR TITLE
Simplify the readme

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.esi.evetech.net

--- a/README.md
+++ b/README.md
@@ -4,28 +4,15 @@ For public ESI issue tracking only. Bring out your dead.
 
 https://esi.evetech.net/
 
-**Please only submit issues related to ESI.**
+**Please only submit issues related to ESI, for SSO issues [click here](https://github.com/ccpgames/sso-issues/issues).**
 
-**[Click here for SSO issues](https://github.com/ccpgames/sso-issues/issues)**
+**Please do not open issues for anything security related here, send an email to [security@ccpgames.com](mailto:security@ccpgames.com) instead.**
 
-**Please do not open issues for anything security related here, send an email to security@ccpgames.com instead.**
+For a list of past and future ESI endpoint changes, see the [changelog](changelog.md).
 
-## Documentation
+This repository is run by a group of CCP developers and members of the EVE third-party dev community. For more details, see [Contributors](contributors.md).
 
-[View ESI documentation here](https://docs.esi.evetech.net/).
-
-ESI documentation is maintained in a separate repository called [esi-docs](https://github.com/esi/esi-docs) and is open to contribute to.
-
-
-## Staying up-to-date
-
-ESI is a constant work in progress. Here is a list of sources you can use to keep updated:
-
-- Follow [@TeamTechCo](https://twitter.com/TeamTechCo), as well as [@CCP_SnowedIn](https://twitter.com/CCP_SnowedIn) and [@CCP_Zoetrope](https://twitter.com/CCP_Zoetrope) on Twitter.
-- Join the [`#esi` channel on Tweetfleet Slack](https://tweetfleet.slack.com/messages/C30KX8UUX/). You can get an invite [here](https://www.fuzzwork.co.uk/tweetfleet-slack-invites/).
-- Read the posts on the [Third Party Developer Blog](https://developers.eveonline.com/blog).
-- Follow the activity in this repository, particularly the [ESI changelog](changelog.md) and [issues that are in progress](https://github.com/esi/esi-issues/labels/in-progress).
-
+The ESI documentation can be found at [https://docs.esi.evetech.net/](https://docs.esi.evetech.net/). A good place to start is the [FAQ](https://docs.esi.evetech.net/docs/FAQ). It is maintained in a separate repository called [esi-docs](https://github.com/esi/esi-docs) and is open for contributions.
 
 ## Opening a new issue
 
@@ -43,7 +30,7 @@ Examples:
 
 Note: `502` or `503` errors are not bugs. Retry your request again in the future.
 
-### [Request a new feature](https://github.com/esi/esi-issues/issues/new?template=feature_request.md)
+### [Request a new feature or an enhancement](https://github.com/esi/esi-issues/issues/new?template=feature_request.md)
 
 Some new features will require game design approval. Do not open duplicate feature requests! If you find something similar to what you're requesting, thumbs up the parent comment and add any addendums as comments.
 
@@ -60,50 +47,8 @@ Examples:
 - two endpoints returning slightly different names for the same attribute
 - attribute values are returned with different formats for different routes (ie; `int32` vs `int64`)
 
-## Migration Guide
-
-### [CREST -> ESI](https://docs.esi.evetech.net/docs/CREST_to_ESI)
-
-### [XML -> ESI](https://docs.esi.evetech.net/docs/XML_to_ESI)
-
-
 ## Issue velocity
 
 [![Waffle.io](https://badge.waffle.io/esi/esi-issues.svg?columns=new,backlog,todo,in+progress,staging)](http://waffle.io/esi/esi-issues)
 
 [![Throughput Graph](https://graphs.waffle.io/esi/esi-issues/throughput.svg)](https://waffle.io/esi/esi-issues/metrics/throughput)
-
-
-## ESI Members
-
- GitHub | CCP Dev Name | Tweetfleet Slack | Twitter | Role
---------|--------------|------------------|---------|------
-[a-tal](https://github.com/a-tal) | CCP SnowedIn | [@ccp_snowedin](https://tweetfleet.slack.com/messages/@ccp_snowedin/) | [@CCP_SnowedIn](https://twitter.com/CCP_SnowedIn) | BDFL
-[aquarhead](https://github.com/aquarhead) | CCP AquarHEAD | [@ccp_aquarhead](https://tweetfleet.slack.com/messages/@ccp_aquarhead/) | [@aquarhead](https://twitter.com/aquarhead) | Developer
-[ccpStuart](https://github.com/ccpStuart) | CCP Mephysto | N/A | N/A | Project Manager
-[ccp-zoetrope](https://github.com/ccp-zoetrope) | CCP Zoetrope | [@ccp_zoetrope](https://tweetfleet.slack.com/messages/@ccp_zoetrope/) | [@CCP_Zoetrope](https://twitter.com/CCP_Zoetrope) | Developer
-[gitAskur](https://github.com/gitAskur) | CCP PrismX | [@prismx](https://tweetfleet.slack.com/messages/@prismx/) | [@CCP_PrismX](https://twitter.com/CCP_PrismX) | Database Wizard
-[HakShak](https://github.com/hakshak) | CCP Chimichanga | [@ccpchimichanga](https://tweetfleet.slack.com/messages/@ccpchimichanga/) | [@ccp_chimichanga](https://twitter.com/ccp_chimichanga) | Manager
-[tsuthers-ccpgames](https://github.com/tsuthers-ccpgames) | CCP Bartender | [@ccp_bartender](https://tweetfleet.slack.com/messages/@ccp_bartender/) | N/A | Developer
-
-
-## ESI Community
-
-The following people are members of the ESI GitHub community. They will be helping to triage issues and guide discussions. Please treat them (and all others) with respect.
-
- GitHub | EVE Character | Tweetfleet Slack | Twitter
---------|---------------|------------------|---------
-[antihax](https://github.com/antihax) | croakroach | [@antihax](https://tweetfleet.slack.com/messages/@antihax/) | [@antihax_croak](https://twitter.com/antihax_croak)
-[rawrasaur](https://github.com/rawrasaur) | Aurora Morgan | [@aurora](https://tweetfleet.slack.com/messages/@aurora/) | [@rawrafox](https://twitter.com/rawrafox)
-[itshouldntdothis](https://github.com/itshouldntdothis) | Beryl Slanjava | [@berylslanjava](https://tweetfleet.slack.com/messages/@berylslanjava/)  | N/A
-[Blacksmoke16](https://github.com/Blacksmoke16) | Blacksmoke16 | [@blacksmoke16](https://tweetfleet.slack.com/messages/@blacksmoke16/) | N/A
-[DianaOlympos](https://github.com/DianaOlympos) | Diana Olympos | [@dianaolympos](https://tweetfleet.slack.com/messages/@dianaolympos/) | [@DianaOlympos](https://twitter.com/DianaOlympos)
-[CarbonAlabel](https://github.com/CarbonAlabel) | Carbon Alabel | [@Carbon](https://tweetfleet.slack.com/messages/@Carbon/) | [@CarbonAlabel](https://twitter.com/CarbonAlabel)
-[lukasni](https://github.com/lukasni) | Catherine Solenne | [@catherinesolenne](https://tweetfleet.slack.com/messages/@catherinesolenne/) | N/A
-[w9jds](https://github.com/w9jds) | Chingy Chonga | [@Chingy Chonga](https://tweetfleet.slack.com/messages/@Chingy_Chonga/) | [@w9jds_](https://twitter.com/w9jds_)
-[NathenSample](https://github.com/NathenSample) | Christy Cloud | [@christycloud](https://tweetfleet.slack.com/messages/@christycloud/) | [@ChristyCloudEve](https://twitter.com/ChristyCloudEve)
-[ddavaham](https://github.com/ddavaham) | David Davaham | [@DoubleD](https://tweetfleet.slack.com/messages/@DoubleD/) | N/A
-[fuzzysteve](https://github.com/fuzzysteve) | Steve Ronuken | [@fuzzysteve](https://tweetfleet.slack.com/messages/@fuzzysteve/) | [@Fuzzysteve](https://twitter.com/Fuzzysteve)
-[GoldenGnu](https://github.com/GoldenGnu) | GoldenGnu | [@goldengnu](https://tweetfleet.slack.com/messages/@goldengnu/) | N/A
-[andimiller](https://github.com/andimiller) | Lucia Denniard | [@luciadenniard](https://tweetfleet.slack.com/messages/@luciadenniard/) | N/A
-[jowrjowr](https://github.com/jowrjowr) | Saeka Tyr | [@saeka](https://tweetfleet.slack.com/messages/@saeka/) | N/A

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-dinky

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,41 @@
+# Contributors
+
+## CCP Developers
+
+The following CCP developers are members of [Team Tech Co](https://twitter.com/TeamTechCo). They are the ones working on ESI (among other projects).
+
+ GitHub | CCP Dev Name | Tweetfleet Slack | Twitter | Role
+--------|--------------|------------------|---------|------
+[a-tal](https://github.com/a-tal) | CCP SnowedIn | [@ccp_snowedin](https://tweetfleet.slack.com/messages/@ccp_snowedin/) | [@CCP_SnowedIn](https://twitter.com/CCP_SnowedIn) | BDFL
+[aquarhead](https://github.com/aquarhead) | CCP AquarHEAD | [@ccp_aquarhead](https://tweetfleet.slack.com/messages/@ccp_aquarhead/) | [@aquarhead](https://twitter.com/aquarhead) | Developer
+[ccpStuart](https://github.com/ccpStuart) | CCP Mephysto | N/A | N/A | Project Manager
+[ccp-zoetrope](https://github.com/ccp-zoetrope) | CCP Zoetrope | [@ccp_zoetrope](https://tweetfleet.slack.com/messages/@ccp_zoetrope/) | [@CCP_Zoetrope](https://twitter.com/CCP_Zoetrope) | Developer
+[gitAskur](https://github.com/gitAskur) | CCP PrismX | [@prismx](https://tweetfleet.slack.com/messages/@prismx/) | [@CCP_PrismX](https://twitter.com/CCP_PrismX) | Database Wizard
+[HakShak](https://github.com/hakshak) | CCP Chimichanga | [@ccpchimichanga](https://tweetfleet.slack.com/messages/@ccpchimichanga/) | [@ccp_chimichanga](https://twitter.com/ccp_chimichanga) | Manager
+[tsuthers-ccpgames](https://github.com/tsuthers-ccpgames) | CCP Bartender | [@ccp_bartender](https://tweetfleet.slack.com/messages/@ccp_bartender/) | N/A | Developer
+
+
+## ESI Community Members
+
+The following people are experienced members of EVE's third-party dev community, who will be helping triage issues and guide discussions. Please treat them (and all others) with respect.
+
+ GitHub | EVE Character | Tweetfleet Slack | Twitter
+--------|---------------|------------------|---------
+[antihax](https://github.com/antihax) | croakroach | [@antihax](https://tweetfleet.slack.com/messages/@antihax/) | [@antihax_croak](https://twitter.com/antihax_croak)
+[rawrasaur](https://github.com/rawrasaur) | Aurora Morgan | [@aurora](https://tweetfleet.slack.com/messages/@aurora/) | [@rawrafox](https://twitter.com/rawrafox)
+[itshouldntdothis](https://github.com/itshouldntdothis) | Beryl Slanjava | [@berylslanjava](https://tweetfleet.slack.com/messages/@berylslanjava/)  | N/A
+[Blacksmoke16](https://github.com/Blacksmoke16) | Blacksmoke16 | [@blacksmoke16](https://tweetfleet.slack.com/messages/@blacksmoke16/) | N/A
+[DianaOlympos](https://github.com/DianaOlympos) | Diana Olympos | [@dianaolympos](https://tweetfleet.slack.com/messages/@dianaolympos/) | [@DianaOlympos](https://twitter.com/DianaOlympos)
+[CarbonAlabel](https://github.com/CarbonAlabel) | Carbon Alabel | [@Carbon](https://tweetfleet.slack.com/messages/@Carbon/) | [@CarbonAlabel](https://twitter.com/CarbonAlabel)
+[lukasni](https://github.com/lukasni) | Catherine Solenne | [@catherinesolenne](https://tweetfleet.slack.com/messages/@catherinesolenne/) | N/A
+[w9jds](https://github.com/w9jds) | Chingy Chonga | [@Chingy Chonga](https://tweetfleet.slack.com/messages/@Chingy_Chonga/) | [@w9jds_](https://twitter.com/w9jds_)
+[NathenSample](https://github.com/NathenSample) | Christy Cloud | [@christycloud](https://tweetfleet.slack.com/messages/@christycloud/) | [@ChristyCloudEve](https://twitter.com/ChristyCloudEve)
+[ddavaham](https://github.com/ddavaham) | David Davaham | [@DoubleD](https://tweetfleet.slack.com/messages/@DoubleD/) | N/A
+[fuzzysteve](https://github.com/fuzzysteve) | Steve Ronuken | [@fuzzysteve](https://tweetfleet.slack.com/messages/@fuzzysteve/) | [@Fuzzysteve](https://twitter.com/Fuzzysteve)
+[GoldenGnu](https://github.com/GoldenGnu) | GoldenGnu | [@goldengnu](https://tweetfleet.slack.com/messages/@goldengnu/) | N/A
+[andimiller](https://github.com/andimiller) | Lucia Denniard | [@luciadenniard](https://tweetfleet.slack.com/messages/@luciadenniard/) | N/A
+[jowrjowr](https://github.com/jowrjowr) | Saeka Tyr | [@saeka](https://tweetfleet.slack.com/messages/@saeka/) | N/A
+
+## Everyone else
+
+Last but not least, a big thanks to all others who have contributed by opening issues, taking part in discussions, or making ESI projects better one commit at a time.


### PR DESCRIPTION
The goal of this PR is to emphasize the purpose of this repository, ESI issue tracking, by shortening and simplifying the readme.

Most of the information about ESI itself has been removed, and readers are instead referred to the new ESI docs, in particular the FAQ. The list of CCP devs and community members has been split into a separate file, and a couple of unused GH Pages config files were removed.