### PR TITLE
Add selectable issue templates from create issue page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,8 @@
+---
+name: Bug
+about: "Report a bug you have encountered using ESI (e.g. unexpected responses). Note: `502` or `503` errors are not bugs. Retry your request again in the future."
+---
+
 # Bug
 
 This template contains an example bug report. Please replace all text except for the checklist and the section headers (they start with \#). Thank you for your contribution to improving ESI.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,8 @@
+---
+name: Feature Request
+about: Suggest new routes or enhancements for existing routes. Do not open duplicate feature requests! Instead, thumbs up the parent comment of a similar issue and join that issue's discussion.
+---
+
 # Feature Request
 
 This template contains an example feature request. Please replace all text except for the checklist and the section headers (they start with \#). Thank you for your contribution to improving ESI.

--- a/.github/ISSUE_TEMPLATE/inconsistency.md
+++ b/.github/ISSUE_TEMPLATE/inconsistency.md
@@ -1,3 +1,8 @@
+---
+name: Inconsistency
+about: Report an inconsistency (e.g. two endpoints returning slightly different names for the same attribute).
+---
+
 # Inconsistency
 
 This template contains an example inconsistency report. Please replace all text except for the checklist and the section headers (they start with \#). Thank you for your contribution to improving ESI.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,0 @@
-# Stop
-
-You're doing it wrong. Go to [Opening a new issue](https://docs.esi.evetech.net/#opening-a-new-issue) and click on one of the links to start with an appropriate issue template.
-
-Issues submitted without a template are likely to be rejected and closed immediately.


### PR DESCRIPTION
Adding a table to the top of an issue template with the properties "name" and
"about" makes Github give those issue templates as selections when creating
a new issue. This is a better flow for issue creation than directing users to
the readme to create an issue.