### PR TITLE
chore: remove label from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report.
-labels: ["bug"]
 type: "Bug"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: File a feature request.
-labels: ["feature request"]
 type: "Feature"
 body:
   - type: markdown


### PR DESCRIPTION
These now all use `type`.